### PR TITLE
fix(next): normalize next env route types

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- update `next-env.d.ts` to reference the generated route types path used by current Next type generation
- remove the stale `.next/dev/types` route types import that caused noisy diffs

## Validation
- pnpm lint