### PR TITLE
[codex] migrate reading question notes

### DIFF
--- a/.agents/skills/reading-question-writer/scripts/migrate-question-notes.mjs
+++ b/.agents/skills/reading-question-writer/scripts/migrate-question-notes.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const sourceDir = path.resolve(process.argv[2] ?? '../question/reading-notes');
+const outputDir = path.resolve(
+  process.argv[3] ?? 'data/work/reading-question-drafts',
+);
+
+const migratedAt = '2026-06-20T00:00:00.000Z';
+
+const overrides = {
+  '2026-05-31_algorithmic-stablecoin-collateral.md': {
+    title: '담보 매각이 스테이블코인의 지급능력을 지탱하는 방식',
+    slug: 'algorithmic-stablecoin-collateral-sales',
+    excerpt:
+      '담보 매각은 지급능력을 새로 만들어내는 일이 아니라, 이미 보유한 담보를 즉시 상환 가능한 현금성 자산으로 바꾸는 과정이다.',
+    whyConfusing:
+      '“담보를 판다”는 표현은 자산을 줄이는 행동처럼 들리기 때문에, 왜 이것이 상환 능력에 도움이 되는지 헷갈리기 쉽다. 핵심은 총자산보다 유동성이다.',
+  },
+  '2026-05-31_bitcoin-ethereum-token-value.md': {
+    title: '비트코인과 이더리움 토큰 가격이 커지는 이유',
+    slug: 'bitcoin-ethereum-token-value',
+    excerpt:
+      '비트코인과 이더리움은 외부 담보에 대한 청구권이 아니므로, 가격은 담보 가치보다 네트워크 신뢰, 사용 수요, 희소성, 보유 수요가 함께 만든다.',
+    whyConfusing:
+      '담보형 토큰을 기준으로 보면 모든 토큰 가격이 준비자산 가치에서 나와야 할 것처럼 보인다. 하지만 비트코인과 이더리움은 토큰 보유자가 외부 자산을 청구하는 구조가 아니다.',
+  },
+  '2026-05-31_quantum-computing-blockchain-security.md': {
+    title: '양자컴퓨팅이 블록체인 보안에 주는 실제 위협',
+    slug: 'quantum-computing-blockchain-security',
+    excerpt:
+      '양자컴퓨터가 블록체인을 즉시 무너뜨리는 것은 아니지만, 충분히 강력해지면 공개키 서명 체계를 교체해야 하는 장기 위험이 된다.',
+    whyConfusing:
+      '블록체인은 여러 암호 기술을 함께 쓰기 때문에 “암호가 뚫린다”는 말이 해시, 서명, 지갑, 합의를 모두 같은 위험으로 보이게 만든다.',
+  },
+  '2026-05-31_stablecoin-usdc.md': {
+    title: 'USDC가 그냥 달러 보유와 다른 점',
+    slug: 'stablecoin-usdc',
+    excerpt:
+      'USDC는 달러보다 가치가 높은 자산이 아니라, 달러 가치를 블록체인에서 전송하고 스마트컨트랙트에 연결하기 위한 토큰이다.',
+    whyConfusing:
+      '가격만 보면 USDC와 달러는 거의 같은 역할을 하므로 차이가 없어 보인다. 하지만 차이는 가치 수준이 아니라 돈이 움직이는 인프라에 있다.',
+  },
+};
+
+function stableKey(...parts) {
+  return createHash('sha1').update(parts.join(':')).digest('hex').slice(0, 12);
+}
+
+function textBlock(text, options = {}) {
+  return {
+    _key: stableKey(options.seed ?? text, options.index ?? ''),
+    _type: 'block',
+    children: [
+      {
+        _key: stableKey('span', options.seed ?? text, options.index ?? ''),
+        _type: 'span',
+        marks: [],
+        text,
+      },
+    ],
+    markDefs: [],
+    style: options.style ?? 'normal',
+    ...(options.listItem
+      ? { listItem: options.listItem, level: options.level ?? 1 }
+      : {}),
+  };
+}
+
+function splitParagraphs(text) {
+  return text
+    .trim()
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.replace(/\n/g, ' ').trim())
+    .filter(Boolean);
+}
+
+function parseNote(markdown) {
+  const title = markdown.match(/^# (.+)$/m)?.[1]?.trim() ?? 'Untitled';
+  const metadata = {};
+  const beforeSections = markdown.split(/^## /m)[0] ?? '';
+
+  for (const line of beforeSections.split('\n')) {
+    const match = line.match(/^([A-Za-z]+):\s*(.*)$/);
+    if (match) {
+      metadata[match[1].toLowerCase()] = match[2].trim();
+    }
+  }
+
+  const sections = {};
+  let currentHeading = null;
+  let currentLines = [];
+
+  for (const line of markdown.split('\n')) {
+    const headingMatch = line.match(/^## (.+)$/);
+
+    if (headingMatch) {
+      if (currentHeading) {
+        sections[currentHeading] = currentLines.join('\n').trim();
+      }
+
+      currentHeading = headingMatch[1].trim();
+      currentLines = [];
+      continue;
+    }
+
+    if (currentHeading) {
+      currentLines.push(line);
+    }
+  }
+
+  if (currentHeading) {
+    sections[currentHeading] = currentLines.join('\n').trim();
+  }
+
+  return { title, metadata, sections };
+}
+
+function parseTags(tagLine = '') {
+  return tagLine
+    .split(/\s+/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function parseBullets(text) {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2).trim())
+    .filter(Boolean);
+}
+
+function heading(text, seed) {
+  return textBlock(text, { style: 'h2', seed: `${seed}:heading:${text}` });
+}
+
+function paragraphBlocks(paragraphs, seed) {
+  return paragraphs.map((paragraph, index) =>
+    textBlock(paragraph, { seed, index }),
+  );
+}
+
+function bulletBlocks(items, seed) {
+  return items.map((item, index) =>
+    textBlock(item, { seed, index, listItem: 'bullet' }),
+  );
+}
+
+function sourceIdFor(fileName) {
+  return `question-reading-notes-${fileName
+    .replace(/\.md$/, '')
+    .replace(/_/g, '-')
+    .replace(/[^a-zA-Z0-9-]/g, '-')}`;
+}
+
+function makeDraft(fileName, markdown) {
+  const note = parseNote(markdown);
+  const override = overrides[fileName] ?? {};
+  const sourceId = sourceIdFor(fileName);
+  const originalQuestion = splitParagraphs(
+    note.sections['Original Question'] ?? '',
+  );
+  const summary = splitParagraphs(note.sections['Conversation Summary'] ?? '');
+  const explanation = splitParagraphs(note.sections.Explanation ?? '');
+  const keyTerms = parseBullets(note.sections['Key Terms'] ?? '');
+  const becameClear = splitParagraphs(note.sections['What Became Clear'] ?? '');
+  const openQuestions = parseBullets(note.sections['Open Questions'] ?? '');
+  const directAnswer = summary.length > 0 ? summary : becameClear;
+
+  return {
+    _type: 'post',
+    title: override.title ?? note.title,
+    slug: {
+      _type: 'slug',
+      current:
+        override.slug ??
+        fileName.replace(/^\d{4}-\d{2}-\d{2}_/, '').replace(/\.md$/, ''),
+    },
+    excerpt: override.excerpt ?? directAnswer[0],
+    contentKind: 'reading-question',
+    sourceMeta: {
+      originSkill: 'reading-question-writer',
+      sourceProject: 'question',
+      sourceId,
+      schemaVersion: 1,
+      generatedAt: migratedAt,
+      sourceTags: parseTags(note.metadata.tags),
+      sourceNotes: [
+        `Migrated from /Users/indegser/Github/question/reading-notes/${fileName}`,
+        note.metadata.source
+          ? `Original source: ${note.metadata.source}`
+          : 'Original source: Unknown',
+        note.metadata.date ? `Original note date: ${note.metadata.date}` : '',
+      ].filter(Boolean),
+    },
+    body: [
+      {
+        _key: stableKey(sourceId, 'original-question-callout'),
+        _type: 'callout',
+        tone: 'question',
+        title: '원래 질문',
+        body: paragraphBlocks(
+          originalQuestion,
+          `${sourceId}:original-question`,
+        ),
+      },
+      ...paragraphBlocks(directAnswer, `${sourceId}:direct-answer`),
+      heading('왜 헷갈렸는가', sourceId),
+      ...paragraphBlocks(
+        [override.whyConfusing].filter(Boolean),
+        `${sourceId}:why`,
+      ),
+      heading('설명', sourceId),
+      ...paragraphBlocks(explanation, `${sourceId}:explanation`),
+      heading('핵심 용어', sourceId),
+      ...bulletBlocks(keyTerms, `${sourceId}:key-terms`),
+      heading('명확해진 점', sourceId),
+      ...paragraphBlocks(becameClear, `${sourceId}:became-clear`),
+      heading('남은 질문', sourceId),
+      ...bulletBlocks(openQuestions, `${sourceId}:open-questions`),
+    ],
+  };
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const files = (await readdir(sourceDir))
+  .filter((file) => /^\d{4}-\d{2}-\d{2}_.+\.md$/.test(file))
+  .sort();
+
+for (const file of files) {
+  const markdown = await readFile(path.join(sourceDir, file), 'utf8');
+  const draft = makeDraft(file, markdown);
+  const target = path.join(outputDir, `${draft.slug.current}.json`);
+
+  await writeFile(target, `${JSON.stringify(draft, null, 2)}\n`);
+  console.log(target);
+}

--- a/data/work/reading-question-drafts/algorithmic-stablecoin-collateral-sales.json
+++ b/data/work/reading-question-drafts/algorithmic-stablecoin-collateral-sales.json
@@ -1,0 +1,381 @@
+{
+  "_type": "post",
+  "title": "담보 매각이 스테이블코인의 지급능력을 지탱하는 방식",
+  "slug": {
+    "_type": "slug",
+    "current": "algorithmic-stablecoin-collateral-sales"
+  },
+  "excerpt": "담보 매각은 지급능력을 새로 만들어내는 일이 아니라, 이미 보유한 담보를 즉시 상환 가능한 현금성 자산으로 바꾸는 과정이다.",
+  "contentKind": "reading-question",
+  "sourceMeta": {
+    "originSkill": "reading-question-writer",
+    "sourceProject": "question",
+    "sourceId": "question-reading-notes-2026-05-31-algorithmic-stablecoin-collateral",
+    "schemaVersion": 1,
+    "generatedAt": "2026-06-20T00:00:00.000Z",
+    "sourceTags": [
+      "#economics",
+      "#crypto",
+      "#stablecoin",
+      "#algorithmic-stablecoin",
+      "#collateral",
+      "#concept",
+      "#reading-note"
+    ],
+    "sourceNotes": [
+      "Migrated from /Users/indegser/Github/question/reading-notes/2026-05-31_algorithmic-stablecoin-collateral.md",
+      "Original source: Unknown",
+      "Original note date: 2026-05-31"
+    ]
+  },
+  "body": [
+    {
+      "_key": "78ee3ea33266",
+      "_type": "callout",
+      "tone": "question",
+      "title": "원래 질문",
+      "body": [
+        {
+          "_key": "ff8f80897663",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "69c3c6d586b0",
+              "_type": "span",
+              "marks": [],
+              "text": "알고리즈믹 스테이블 코인은 지급능력을 유지하기 위해 담보물을 자동으로 판대. < 이거 매커니즘을 잘 이해 못했어"
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        },
+        {
+          "_key": "875e7075fa9c",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "8dbe7ed1fc1d",
+              "_type": "span",
+              "marks": [],
+              "text": "숫자 예시에서 일부 담보를 파는게 어떻게 갚을 능력이 있다는거야?"
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        }
+      ]
+    },
+    {
+      "_key": "0cd33e4d769d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "fd29833c6d00",
+          "_type": "span",
+          "marks": [],
+          "text": "알고리즘 스테이블코인 또는 담보와 알고리즘이 결합된 스테이블코인은 목표 가격을 유지하기 위해 자동 규칙으로 공급량, 담보, 상환 가능 자산을 조절한다. 담보를 판다는 것은 지급능력을 새로 만들어내는 행위라기보다, 이미 있는 담보 가치를 당장 상환에 쓸 수 있는 현금성 자산으로 바꾸는 행위에 가깝다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "05a2e6a43aaf",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "8ca49fb66c2e",
+          "_type": "span",
+          "marks": [],
+          "text": "왜 헷갈렸는가"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "f82172ba51be",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "32bf1dd7fdc9",
+          "_type": "span",
+          "marks": [],
+          "text": "“담보를 판다”는 표현은 자산을 줄이는 행동처럼 들리기 때문에, 왜 이것이 상환 능력에 도움이 되는지 헷갈리기 쉽다. 핵심은 총자산보다 유동성이다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "a85fcc041d5c",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "96661f637a08",
+          "_type": "span",
+          "marks": [],
+          "text": "설명"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "b45b9b132f28",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4cbd69fc78bc",
+          "_type": "span",
+          "marks": [],
+          "text": "스테이블코인은 보통 1코인이 1달러 같은 기준 가격을 유지하도록 설계된다. 이를 위해 시스템은 자신이 발행한 코인을 나중에 상환할 수 있을 만큼 충분한 자산을 갖고 있어야 한다. 이 능력을 지급능력이라고 볼 수 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "ea3361808aa6",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "764762e65775",
+          "_type": "span",
+          "marks": [],
+          "text": "담보가 ETH 같은 변동성 자산이라면 장부상으로는 충분한 가치가 있어도, 사람들이 즉시 상환을 요구할 때 바로 지급하기 어렵다. 그래서 시스템은 담보 일부를 팔아 달러, USDC 같은 현금성 자산을 확보한다. 이는 자산 총액을 늘리는 것이 아니라, 자산의 형태를 \"가격이 흔들리는 담보\"에서 \"상환에 바로 쓸 수 있는 자산\"으로 바꾸는 것이다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "def03ba050c6",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "972ab8703788",
+          "_type": "span",
+          "marks": [],
+          "text": "예를 들어 시스템이 100달러어치 스테이블코인을 발행했고, ETH 담보를 120달러어치 갖고 있다면 순자산 기준으로는 갚을 능력이 있다. 하지만 상환 요청이 들어오면 ETH를 그대로 줄 수 없거나 가격 변동 위험이 크므로, 일부 ETH를 팔아 현금 50달러를 만든다. 그러면 총자산 가치는 대략 그대로지만, 그중 일부가 즉시 상환 가능한 형태가 된다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "fe562cdf4599",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "36edfcb77873",
+          "_type": "span",
+          "marks": [],
+          "text": "중요한 구분은 두 가지다. 첫째, 순자산 기준 지급능력은 가진 자산 총액이 부채보다 큰지를 보는 것이다. 둘째, 유동성 기준 지급능력은 사람들이 지금 상환을 요구할 때 실제로 줄 수 있는 현금성 자산이 있는지를 보는 것이다. 담보 매각은 특히 두 번째 문제, 즉 유동성 확보와 가격 하락 위험 방어에 관련된다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "0e10ae43ccee",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "1fa9179ed49d",
+          "_type": "span",
+          "marks": [],
+          "text": "핵심 용어"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "73866b31e6cd",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "77bdafadc51f",
+          "_type": "span",
+          "marks": [],
+          "text": "Algorithmic stablecoin: 목표 가격을 유지하기 위해 자동 규칙으로 공급량이나 담보 운용을 조절하는 스테이블코인"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "589431bf355d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "ac053615fa8d",
+          "_type": "span",
+          "marks": [],
+          "text": "Collateral: 발행된 코인의 가치를 뒷받침하기 위해 보유하는 담보 자산"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "d35ba03b16b9",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "d1a489453e03",
+          "_type": "span",
+          "marks": [],
+          "text": "Solvency: 총자산이 총부채를 감당할 수 있는 상태"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "f640307077c0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "d3d69e93338f",
+          "_type": "span",
+          "marks": [],
+          "text": "Liquidity: 자산을 빠르게 현금성 자산으로 바꾸거나 즉시 지급할 수 있는 능력"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "42337ba81013",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "1fe90127038b",
+          "_type": "span",
+          "marks": [],
+          "text": "Redemption: 사용자가 스테이블코인을 기준 자산으로 상환받는 과정"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "ae9bd1dc7f8b",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "21aff0fe0bdd",
+          "_type": "span",
+          "marks": [],
+          "text": "Peg: 코인 가격을 1달러 같은 목표 가격에 맞추려는 구조"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "527ea76ad180",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "67cb318f39d6",
+          "_type": "span",
+          "marks": [],
+          "text": "명확해진 점"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "f37bb170b97e",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b05b35515980",
+          "_type": "span",
+          "marks": [],
+          "text": "담보를 자동으로 판다고 해서 시스템의 부채 상환 능력이 마법처럼 생기는 것은 아니다. 이미 갖고 있던 담보 가치를 상환 가능한 돈으로 바꾸고, 담보 가격이 더 떨어지기 전에 위험을 줄이는 것이다. 따라서 담보 매각은 \"자산 총액 증가\"가 아니라 \"상환 가능한 형태로 전환\"에 가깝다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "1665a0963017",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "8d52945bd9d7",
+          "_type": "span",
+          "marks": [],
+          "text": "남은 질문"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "f700d5dc2ec3",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "f2b1a6aa471c",
+          "_type": "span",
+          "marks": [],
+          "text": "담보형 스테이블코인과 순수 알고리즘 스테이블코인은 실제로 어떻게 다른가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "cf04fd27989f",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "59e74861cac9",
+          "_type": "span",
+          "marks": [],
+          "text": "담보 가격이 너무 빨리 떨어지면 자동 매각은 어디까지 효과가 있는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "d01c78ccbf98",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "8858de1546b6",
+          "_type": "span",
+          "marks": [],
+          "text": "과거에 스테이블코인 페그가 무너진 사례에는 어떤 메커니즘 실패가 있었는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    }
+  ]
+}

--- a/data/work/reading-question-drafts/bitcoin-ethereum-token-value.json
+++ b/data/work/reading-question-drafts/bitcoin-ethereum-token-value.json
@@ -1,0 +1,413 @@
+{
+  "_type": "post",
+  "title": "비트코인과 이더리움 토큰 가격이 커지는 이유",
+  "slug": {
+    "_type": "slug",
+    "current": "bitcoin-ethereum-token-value"
+  },
+  "excerpt": "비트코인과 이더리움은 외부 담보에 대한 청구권이 아니므로, 가격은 담보 가치보다 네트워크 신뢰, 사용 수요, 희소성, 보유 수요가 함께 만든다.",
+  "contentKind": "reading-question",
+  "sourceMeta": {
+    "originSkill": "reading-question-writer",
+    "sourceProject": "question",
+    "sourceId": "question-reading-notes-2026-05-31-bitcoin-ethereum-token-value",
+    "schemaVersion": 1,
+    "generatedAt": "2026-06-20T00:00:00.000Z",
+    "sourceTags": [
+      "#economics",
+      "#crypto",
+      "#bitcoin",
+      "#ethereum",
+      "#tokenomics",
+      "#concept",
+      "#reading-note"
+    ],
+    "sourceNotes": [
+      "Migrated from /Users/indegser/Github/question/reading-notes/2026-05-31_bitcoin-ethereum-token-value.md",
+      "Original source: Unknown",
+      "Original note date: 2026-05-31"
+    ]
+  },
+  "body": [
+    {
+      "_key": "7e2d21adc4d3",
+      "_type": "callout",
+      "tone": "question",
+      "title": "원래 질문",
+      "body": [
+        {
+          "_key": "5000589b1ab8",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "151063f4519e",
+              "_type": "span",
+              "marks": [],
+              "text": "토큰 기반의 지속 가능한 금융 모델? 토큰 가격은 결국 담보물의 가치에 의해 결정되는거 아니야?"
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        },
+        {
+          "_key": "564841b863c2",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "75dd0a6408a6",
+              "_type": "span",
+              "marks": [],
+              "text": "이더리움이나 비트코인의 토큰 금액의 성장을 이관점으로 설명해봐. 서비스 사용처가 늘어나면서 토큰 가격이 증가했어?"
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        }
+      ]
+    },
+    {
+      "_key": "a37a81109953",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "d9dccb95fde6",
+          "_type": "span",
+          "marks": [],
+          "text": "담보 기반 토큰은 담보물의 가치가 가격의 중요한 기준점이 된다. 하지만 비트코인과 이더리움은 금, 달러, 국채 같은 외부 담보에 대한 청구권이 아니다. 따라서 이들의 가격은 담보 가치가 아니라 네트워크에 대한 신뢰, 사용 수요, 보유 수요, 희소성, 유동성, 투기적 기대, 거시경제 환경 등이 함께 만든 결과로 이해해야 한다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "0fee1637863a",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "653051852137",
+          "_type": "span",
+          "marks": [],
+          "text": "왜 헷갈렸는가"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "ac6d6295af4f",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "7e54095c8c21",
+          "_type": "span",
+          "marks": [],
+          "text": "담보형 토큰을 기준으로 보면 모든 토큰 가격이 준비자산 가치에서 나와야 할 것처럼 보인다. 하지만 비트코인과 이더리움은 토큰 보유자가 외부 자산을 청구하는 구조가 아니다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "1668a6f2b97a",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "7271fda81c0e",
+          "_type": "span",
+          "marks": [],
+          "text": "설명"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "6be7ec9ff294",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "2a06bc733ebf",
+          "_type": "span",
+          "marks": [],
+          "text": "담보 기반 토큰은 토큰을 보유한 사람이 실제 자산이나 현금흐름을 청구할 수 있을 때 가치 기준이 비교적 명확하다. 예를 들어 1토큰이 1달러 예치금에 대한 청구권이라면, 토큰 가격은 그 담보와 상환 가능성에 강하게 묶인다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "cdef0de00712",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "37b01d51fcab",
+          "_type": "span",
+          "marks": [],
+          "text": "비트코인은 이런 의미의 담보가 없다. 1 BTC를 들고 있다고 해서 금, 달러, 회사 지분, 현금흐름을 청구할 수 있는 것은 아니다. 비트코인의 가치는 주로 희소성, 검열 저항성, 자기 보관 가능성, 장기적 가치 저장 수단이라는 사회적 믿음에서 나온다. 그래서 비트코인의 가격 상승은 \"서비스 사용처가 많아져서\"라기보다, 제한된 공급을 가진 디지털 자산을 보유하려는 수요와 제도권 접근성이 커진 결과로 보는 편이 더 정확하다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "c3422a060108",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "bd84eec3885b",
+          "_type": "span",
+          "marks": [],
+          "text": "이더리움은 비트코인보다 서비스 사용처 증가로 설명하기 쉽다. ETH는 이더리움 네트워크에서 거래 수수료를 내는 자산이고, DeFi, NFT, 스테이블코인 전송, DAO, 토큰 발행, 레이어2 정산 등 다양한 활동에 필요하다. 네트워크에서 할 수 있는 일이 늘어나면 ETH는 수수료 자산, 담보 자산, 정산 자산으로 더 많이 요구될 수 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "934f0ff61dae",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "2220c18d69f4",
+          "_type": "span",
+          "marks": [],
+          "text": "다만 서비스 사용처 증가가 자동으로 가격 상승을 보장하지는 않는다. 사용자가 많아도 토큰을 오래 보유할 필요가 없으면 가격 압력이 약할 수 있고, 앱의 성공이 반드시 기본 토큰의 가치로 귀속되지 않을 수도 있다. 실제 가격은 사용 수요뿐 아니라 담보 수요, 투기 수요, 공급 구조, 소각 메커니즘, 금리, 규제, 전체 시장 유동성까지 함께 반영한다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "d851e47a0802",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "587631f46bce",
+          "_type": "span",
+          "marks": [],
+          "text": "핵심 용어"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "2a630fa7ef07",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "16e03734fc02",
+          "_type": "span",
+          "marks": [],
+          "text": "Collateral-backed token: 외부 자산이나 준비금으로 뒷받침되는 토큰"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "dc14a027caa4",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "224991cb89bf",
+          "_type": "span",
+          "marks": [],
+          "text": "Bitcoin: 외부 담보 없이 희소성, 네트워크 신뢰, 가치 저장 수요를 중심으로 가격이 형성되는 암호자산"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "53b4fa9a5308",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b61764d6f7d8",
+          "_type": "span",
+          "marks": [],
+          "text": "Ethereum: 스마트컨트랙트 네트워크이며 ETH는 수수료, 담보, 정산 자산으로 쓰임"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "e3642ae4d454",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "f9126c8ea13f",
+          "_type": "span",
+          "marks": [],
+          "text": "Utility demand: 네트워크나 서비스를 실제로 사용하기 위해 생기는 토큰 수요"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "bc65a3c7dce9",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "e31c84957d4a",
+          "_type": "span",
+          "marks": [],
+          "text": "Store of value: 시간이 지나도 가치를 보존할 수 있다고 여겨지는 자산의 성격"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "786adad05e4a",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "a735448dde8d",
+          "_type": "span",
+          "marks": [],
+          "text": "Token value accrual: 네트워크나 앱에서 생긴 가치가 특정 토큰 가격이나 수요로 귀속되는 과정"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "ef1ab6010851",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4e5290435fc1",
+          "_type": "span",
+          "marks": [],
+          "text": "Fee burn: 네트워크 수수료 일부를 소각해 공급 증가 압력을 줄이는 구조"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "5b9ef56d7971",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "0ac61cea8d80",
+          "_type": "span",
+          "marks": [],
+          "text": "명확해진 점"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "c5456e4ef02c",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "25bc3ba6a21d",
+          "_type": "span",
+          "marks": [],
+          "text": "담보 기반 토큰은 담보물이 핵심 가치 기준이지만, 비트코인과 이더리움은 담보물에 대한 청구권이 아니다. 비트코인은 사용처보다 희소성과 가치 저장 수요가 중심이고, 이더리움은 네트워크 사용처 증가가 ETH 수요를 설명하는 데 더 직접적으로 연결된다. 하지만 두 경우 모두 가격은 실제 사용 수요만으로 결정되지 않고, 신뢰와 기대, 거시 유동성, 제도권 접근성까지 함께 반영된다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "f9588ae7459e",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "875b03a9bced",
+          "_type": "span",
+          "marks": [],
+          "text": "남은 질문"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "92eafb994c30",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "1a47cd58c604",
+          "_type": "span",
+          "marks": [],
+          "text": "이더리움 네트워크의 성공이 항상 ETH 가격으로 귀속되는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "9bd69f45b2f9",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "513bb62da8ba",
+          "_type": "span",
+          "marks": [],
+          "text": "토큰의 실제 사용 수요와 투기 수요를 어떻게 구분할 수 있는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "ab3d050e7699",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "6272d9a78cdc",
+          "_type": "span",
+          "marks": [],
+          "text": "비트코인의 가치 저장 수단 서사는 어떤 조건에서 약해질 수 있는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "c14a9c5dcb74",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b5b797a32099",
+          "_type": "span",
+          "marks": [],
+          "text": "담보 없는 토큰이 지속 가능한 금융 모델이 되려면 어떤 현금흐름이나 권리 구조가 필요한가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    }
+  ]
+}

--- a/data/work/reading-question-drafts/quantum-computing-blockchain-security.json
+++ b/data/work/reading-question-drafts/quantum-computing-blockchain-security.json
@@ -1,0 +1,452 @@
+{
+  "_type": "post",
+  "title": "양자컴퓨팅이 블록체인 보안에 주는 실제 위협",
+  "slug": {
+    "_type": "slug",
+    "current": "quantum-computing-blockchain-security"
+  },
+  "excerpt": "양자컴퓨터가 블록체인을 즉시 무너뜨리는 것은 아니지만, 충분히 강력해지면 공개키 서명 체계를 교체해야 하는 장기 위험이 된다.",
+  "contentKind": "reading-question",
+  "sourceMeta": {
+    "originSkill": "reading-question-writer",
+    "sourceProject": "question",
+    "sourceId": "question-reading-notes-2026-05-31-quantum-computing-blockchain-security",
+    "schemaVersion": 1,
+    "generatedAt": "2026-06-20T00:00:00.000Z",
+    "sourceTags": [
+      "#blockchain",
+      "#cryptography",
+      "#quantum-computing",
+      "#post-quantum",
+      "#security",
+      "#reading-note"
+    ],
+    "sourceNotes": [
+      "Migrated from /Users/indegser/Github/question/reading-notes/2026-05-31_quantum-computing-blockchain-security.md",
+      "Original source: Unknown",
+      "Original note date: 2026-05-31"
+    ]
+  },
+  "body": [
+    {
+      "_key": "511b66864f8e",
+      "_type": "callout",
+      "tone": "question",
+      "title": "원래 질문",
+      "body": [
+        {
+          "_key": "97642a3bd46c",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "c2b2e494f9a5",
+              "_type": "span",
+              "marks": [],
+              "text": "양자컴퓨터가 요새 뜨던데 이거 나오면 암호화폐 또는 블록체인은 어떻게 될까? 암호화가 다 뚫리잖아"
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        }
+      ]
+    },
+    {
+      "_key": "c1656efa5669",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "0cc779e0006a",
+          "_type": "span",
+          "marks": [],
+          "text": "양자컴퓨터가 등장하면 블록체인이 즉시 모두 무너지는 것은 아니지만, 현재 블록체인이 많이 쓰는 공개키 서명 체계는 장기적으로 위험해질 수 있다. 특히 Bitcoin의 ECDSA/Schnorr, Ethereum의 ECDSA/BLS 같은 서명 방식은 충분히 강한 양자컴퓨터가 나오면 공개키에서 개인키를 역산당할 수 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "b77363184dd0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "6c0e4077c001",
+          "_type": "span",
+          "marks": [],
+          "text": "반면 SHA-256 같은 해시 함수는 양자컴퓨터로도 완전히 무력화되는 것이 아니라 보안 강도가 낮아지는 쪽에 가깝다. 따라서 핵심 위험은 \"블록체인 전체 기록이 깨진다\"보다는 \"공개키가 노출된 지갑의 서명이 위조될 수 있다\"에 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "b87464d2c793",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4f736716c2e0",
+          "_type": "span",
+          "marks": [],
+          "text": "주요 체인들은 이미 post-quantum cryptography로의 전환을 준비하고 있다. Bitcoin은 BIP-360, BIP-361 같은 초안 단계의 제안이 있고, Ethereum은 account abstraction과 leanXMSS/leanVM 등을 포함한 로드맵을 진행 중이다. Solana는 Falcon 기반 경로를 연구하고, Algorand는 Falcon 서명 기반 양자내성 거래를 메인넷에서 실행한 사례가 있다. XRP Ledger와 Polkadot도 각각 로드맵을 공개했다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "ddca145969e4",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "9481df495c99",
+          "_type": "span",
+          "marks": [],
+          "text": "왜 헷갈렸는가"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "b03130c5e2a2",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "6ff60677a424",
+          "_type": "span",
+          "marks": [],
+          "text": "블록체인은 여러 암호 기술을 함께 쓰기 때문에 “암호가 뚫린다”는 말이 해시, 서명, 지갑, 합의를 모두 같은 위험으로 보이게 만든다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "a67560b53a2f",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "e718f911c740",
+          "_type": "span",
+          "marks": [],
+          "text": "설명"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "cb16373579e0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b0511f0bd2d5",
+          "_type": "span",
+          "marks": [],
+          "text": "양자컴퓨터의 위협은 블록체인의 모든 암호 요소에 똑같이 작용하지 않는다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "ef32a0eb10db",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "87d2f3c61bbf",
+          "_type": "span",
+          "marks": [],
+          "text": "해시 함수는 무작위 번호를 맞히는 문제에 가깝다. 양자 알고리즘은 이 탐색을 빠르게 만들 수 있지만, SHA-256 같은 해시는 여전히 상당한 보안 여유가 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "dcf947052d42",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "fb1c9aa89340",
+          "_type": "span",
+          "marks": [],
+          "text": "전자서명은 다르다. 사용자가 거래에 서명하면 공개키가 체인에 드러날 수 있고, 충분히 강한 양자컴퓨터는 쇼어 알고리즘을 통해 공개키에서 개인키를 계산할 가능성이 있다. 그래서 한 번도 송금하지 않은 주소와 이미 송금해서 공개키가 노출된 주소의 위험도는 다르다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "a2a6305855cc",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4260cfdafc64",
+          "_type": "span",
+          "marks": [],
+          "text": "양자컴퓨터가 블록체인을 Visa급 처리속도로 직접 끌어올릴 가능성은 낮다. 블록체인의 속도 병목은 단순 계산 능력보다 네트워크 합의, 데이터 전파, 저장공간, 검증 비용, 탈중앙성 유지에 더 크게 걸려 있기 때문이다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "9a49c0e96322",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4f005b647f44",
+          "_type": "span",
+          "marks": [],
+          "text": "하지만 양자컴퓨터의 등장은 블록체인 생태계를 더 안전하고 성숙하게 만들 수 있다. 양자 위협에 대응하면서 양자내성 서명, 키 회전, 계정 추상화, 복구 지갑, 다중서명, ZK와 해시 기반 증명 같은 기술이 발전할 수 있기 때문이다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "eb1066bc5f3b",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "cdfaee16504c",
+          "_type": "span",
+          "marks": [],
+          "text": "핵심 용어"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "2182c658b13d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "22ec77f2c20c",
+          "_type": "span",
+          "marks": [],
+          "text": "Quantum computer: 특정 수학 문제를 고전 컴퓨터보다 훨씬 빠르게 풀 수 있는 계산 장치."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "d0d9904f1521",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "5fd59119c9ca",
+          "_type": "span",
+          "marks": [],
+          "text": "Shor's algorithm: RSA나 ECC 계열 공개키 암호를 위협하는 양자 알고리즘."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "93d6767fbdad",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "f55728088df3",
+          "_type": "span",
+          "marks": [],
+          "text": "Hash function: 데이터를 고정 길이 값으로 바꾸는 함수. 블록체인에서는 블록 연결과 주소 생성 등에 쓰인다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "ec169bcae822",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "abeec9eb8bf4",
+          "_type": "span",
+          "marks": [],
+          "text": "Digital signature: 개인키로 거래를 승인하고 공개키로 검증하는 암호 기술."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "e2bf125707b0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "12bcffbef3d8",
+          "_type": "span",
+          "marks": [],
+          "text": "Post-quantum cryptography: 양자컴퓨터 공격에도 안전하다고 여겨지는 암호 기술."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "ebdfa8665a4d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "5cefba754c62",
+          "_type": "span",
+          "marks": [],
+          "text": "Account abstraction: 계정의 서명 검증 방식을 더 유연하게 바꿀 수 있게 하는 설계."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "01a6dc526ca1",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b8f0792dbdd4",
+          "_type": "span",
+          "marks": [],
+          "text": "Falcon, ML-DSA, SLH-DSA: 양자내성 서명 후보 또는 표준 계열."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "53f0c49ee6f0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "0255e1faa3ca",
+          "_type": "span",
+          "marks": [],
+          "text": "명확해진 점"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "ea77803f3778",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4455fb2485d5",
+          "_type": "span",
+          "marks": [],
+          "text": "양자컴퓨터가 나오면 블록체인이 자동으로 끝나는 것이 아니라, 현재 서명 체계가 장기적으로 교체되어야 한다는 점이 분명해졌다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "86c194237e1d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "da0fc611945b",
+          "_type": "span",
+          "marks": [],
+          "text": "위험의 중심은 해시보다 전자서명이며, 특히 공개키가 이미 노출된 지갑이 더 취약하다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "1912bb73090a",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "006024112799",
+          "_type": "span",
+          "marks": [],
+          "text": "양자컴퓨터 자체가 블록체인의 TPS를 바로 높여주는 것은 아니지만, 그 위협 때문에 블록체인이 더 안전한 암호 구조와 지갑 구조로 발전할 수 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "a33ba1a4b2bf",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "48aa39754e11",
+          "_type": "span",
+          "marks": [],
+          "text": "남은 질문"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "d48348ce38f2",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "6d81b5add4ae",
+          "_type": "span",
+          "marks": [],
+          "text": "각 주요 체인이 실제로 언제 post-quantum 서명을 메인넷 기본 기능으로 도입할까?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "612d3f4bd9a5",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "ddcfc809abaf",
+          "_type": "span",
+          "marks": [],
+          "text": "기존에 공개키가 노출된 오래된 지갑과 분실 지갑은 어떻게 처리될까?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "912ecdfe231a",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "c3e00ae8f0ac",
+          "_type": "span",
+          "marks": [],
+          "text": "양자내성 서명의 큰 크기와 검증 비용을 블록체인에서 어떻게 효율적으로 감당할까?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    }
+  ]
+}

--- a/data/work/reading-question-drafts/stablecoin-usdc.json
+++ b/data/work/reading-question-drafts/stablecoin-usdc.json
@@ -1,0 +1,352 @@
+{
+  "_type": "post",
+  "title": "USDC가 그냥 달러 보유와 다른 점",
+  "slug": {
+    "_type": "slug",
+    "current": "stablecoin-usdc"
+  },
+  "excerpt": "USDC는 달러보다 가치가 높은 자산이 아니라, 달러 가치를 블록체인에서 전송하고 스마트컨트랙트에 연결하기 위한 토큰이다.",
+  "contentKind": "reading-question",
+  "sourceMeta": {
+    "originSkill": "reading-question-writer",
+    "sourceProject": "question",
+    "sourceId": "question-reading-notes-2026-05-31-stablecoin-usdc",
+    "schemaVersion": 1,
+    "generatedAt": "2026-06-20T00:00:00.000Z",
+    "sourceTags": [
+      "#economics",
+      "#crypto",
+      "#stablecoin",
+      "#definition",
+      "#concept",
+      "#reading-note"
+    ],
+    "sourceNotes": [
+      "Migrated from /Users/indegser/Github/question/reading-notes/2026-05-31_stablecoin-usdc.md",
+      "Original source: Unknown",
+      "Original note date: 2026-05-31"
+    ]
+  },
+  "body": [
+    {
+      "_key": "e7d4273ee0ae",
+      "_type": "callout",
+      "tone": "question",
+      "title": "원래 질문",
+      "body": [
+        {
+          "_key": "4b32351ab6a2",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "8314aa4744aa",
+              "_type": "span",
+              "marks": [],
+              "text": "법정 화폐와 일대일 교환을 보장하는 USDC 코인 같은 스테이블코인은 장점이 뭐야? 그냥 달러를 소유하는거랑 똑같은거잖아"
+            }
+          ],
+          "markDefs": [],
+          "style": "normal"
+        }
+      ]
+    },
+    {
+      "_key": "17ec7deef5af",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "47df36fa8c19",
+          "_type": "span",
+          "marks": [],
+          "text": "USDC 같은 스테이블코인은 가격 면에서는 달러와 거의 같은 역할을 하려 하지만, 본질적인 차이는 달러 가치가 블록체인 위의 토큰 형태로 존재한다는 점이다. 그래서 단순히 \"달러를 들고 있는 것\"이 아니라, 달러 가치를 빠르게 전송하고 스마트컨트랙트에서 사용할 수 있게 만든 자산으로 이해할 수 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "9f3a4b50e32d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "f4c46b31e386",
+          "_type": "span",
+          "marks": [],
+          "text": "왜 헷갈렸는가"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "aae2c5575fa2",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "98c9509786f0",
+          "_type": "span",
+          "marks": [],
+          "text": "가격만 보면 USDC와 달러는 거의 같은 역할을 하므로 차이가 없어 보인다. 하지만 차이는 가치 수준이 아니라 돈이 움직이는 인프라에 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "67b6abc7bdb5",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "937ecd1b8f07",
+          "_type": "span",
+          "marks": [],
+          "text": "설명"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "47b63bca5930",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "9b7ace346c7d",
+          "_type": "span",
+          "marks": [],
+          "text": "달러는 은행 시스템 안에서 움직이는 돈이고, USDC는 달러 가치를 추적하는 블록체인 토큰이다. 따라서 USDC의 장점은 달러보다 가치가 높다는 데 있지 않고, 달러 가치를 인터넷 네이티브 자산처럼 이동시키고 조합할 수 있다는 데 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "c3d23a564402",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "6b451dd36147",
+          "_type": "span",
+          "marks": [],
+          "text": "USDC 같은 스테이블코인은 전 세계 지갑 간 전송, 거래소 안에서의 현금성 대기 자금, DeFi 담보와 대출, 자동 정산, 앱 내 결제 등에 쓰일 수 있다. 특히 스마트컨트랙트에서 바로 사용할 수 있다는 점이 은행 계좌의 달러와 크게 다르다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "9caca6b4163c",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "a48d56901420",
+          "_type": "span",
+          "marks": [],
+          "text": "다만 스테이블코인은 발행사의 준비금 관리, 규제, 블록체인 수수료와 장애, 지갑 키 분실, 일시적인 가격 이탈 같은 위험을 가진다. 은행 안에서만 쓸 돈이라면 일반 달러가 더 단순할 수 있고, 블록체인 생태계 안에서 쓸 돈이라면 USDC 같은 스테이블코인이 더 유용할 수 있다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "90797913eb8b",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "d6e3d497d6e2",
+          "_type": "span",
+          "marks": [],
+          "text": "핵심 용어"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "7dfcce20a986",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "ff9e629dbb84",
+          "_type": "span",
+          "marks": [],
+          "text": "Stablecoin: 특정 자산의 가치에 고정되도록 설계된 암호화폐"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "98c3c16037f9",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b4dee5d1c66d",
+          "_type": "span",
+          "marks": [],
+          "text": "USDC: Circle이 발행하는 미국 달러 연동 스테이블코인"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "e95c63a4dffc",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "b15e6705e48e",
+          "_type": "span",
+          "marks": [],
+          "text": "Fiat-backed stablecoin: 법정화폐나 단기 국채 같은 준비자산으로 뒷받침되는 스테이블코인"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "e2425d1d000d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "71f80659863f",
+          "_type": "span",
+          "marks": [],
+          "text": "Smart contract: 조건에 따라 자동 실행되는 블록체인상의 프로그램"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "62bfc6a5bead",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "633e28ea5a7c",
+          "_type": "span",
+          "marks": [],
+          "text": "DeFi: 은행이나 중개기관 없이 블록체인 위에서 작동하는 금융 서비스"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "8086e195217d",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "aabffe14c1a6",
+          "_type": "span",
+          "marks": [],
+          "text": "Peg: 어떤 자산의 가격을 특정 기준 가격에 맞추려는 구조"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "7a13ca736bd0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "4067fc1a4f44",
+          "_type": "span",
+          "marks": [],
+          "text": "명확해진 점"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "26140658bb20",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "fcf72cb119ac",
+          "_type": "span",
+          "marks": [],
+          "text": "USDC는 \"달러보다 나은 가치 저장 수단\"이라기보다 \"달러 가치를 블록체인에서 쓸 수 있게 만든 토큰\"에 가깝다. 핵심 장점은 빠른 전송, 글로벌 접근성, 거래소 내 현금 역할, 스마트컨트랙트와의 결합 가능성이다."
+        }
+      ],
+      "markDefs": [],
+      "style": "normal"
+    },
+    {
+      "_key": "61e9d6142b67",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "9253ee0615b6",
+          "_type": "span",
+          "marks": [],
+          "text": "남은 질문"
+        }
+      ],
+      "markDefs": [],
+      "style": "h2"
+    },
+    {
+      "_key": "5afce4e83d82",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "484983bf19fb",
+          "_type": "span",
+          "marks": [],
+          "text": "USDC와 비슷한 다른 스테이블코인에는 무엇이 있는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "f11cdffd02b0",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "8e57b1230819",
+          "_type": "span",
+          "marks": [],
+          "text": "스테이블코인은 국가별 통화에 맞춰서도 발행되는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    },
+    {
+      "_key": "70be0c781e22",
+      "_type": "block",
+      "children": [
+        {
+          "_key": "bca36e8df8ae",
+          "_type": "span",
+          "marks": [],
+          "text": "달러 연동 스테이블코인과 유로, 엔화, 싱가포르달러 연동 스테이블코인은 어떤 차이가 있는가?"
+        }
+      ],
+      "markDefs": [],
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a migration script for the old `question` project's reading notes.
- Add four generated `reading-question` draft artifacts under `data/work/reading-question-drafts`.
- Preserve source metadata so the drafts can be traced back to `/Users/indegser/Github/question/reading-notes`.

## Validation
- `pnpm exec prettier --check .agents/skills/reading-question-writer/scripts/migrate-question-notes.mjs data/work/reading-question-drafts/*.json`
- `node .agents/skills/post-content-writer/scripts/validate-post-draft.mjs` for each migrated draft JSON
- Pre-commit `lint-staged` passed during commit

## Notes
- Existing unrelated local changes were left unstaged.